### PR TITLE
Android 7 support, note titles, static element removal, etc

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 24
+    buildToolsVersion "24.0.3"
     defaultConfig {
         applicationId "com.tomaszmarzeion.notepad"
         minSdkVersion 15
-        targetSdkVersion 23
+        targetSdkVersion 24
         versionCode 7
         versionName "1.12 hotfix"
     }
@@ -26,7 +26,7 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.android.support:design:23.1.1'
-    compile 'com.android.support:support-v4:23.1.1'
+    compile 'com.android.support:appcompat-v7:24.2.1'
+    compile 'com.android.support:design:24.2.1'
+    compile 'com.android.support:support-v4:24.2.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,6 @@
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
-            android:screenOrientation="portrait"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -22,7 +21,7 @@
         <activity
             android:name=".NoteActivity"
             android:label="@string/add_note"
-            android:screenOrientation="portrait"/>
+            android:screenOrientation="locked"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/tomek/notepad/DatabaseHandler.java
+++ b/app/src/main/java/com/example/tomek/notepad/DatabaseHandler.java
@@ -3,6 +3,7 @@ package com.example.tomek.notepad;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
+import android.database.DatabaseUtils;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 import android.database.sqlite.SQLiteOpenHelper;
@@ -14,7 +15,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
+import java.util.Locale;
 
 /**
  * DatabaseHandler class used for Creating, Accessing and Modifying SQLite Database
@@ -30,7 +31,7 @@ public class DatabaseHandler extends SQLiteOpenHelper {
     private static final String KEY_SPANNABLE_NOTE = "serializedSpannableNote";
     private static final String KEY_IMAGE = "image";
     private static final String KEY_DATE_UPDATED = "dateUpdated";
-    private static final DateFormat dt = new SimpleDateFormat("dd.MM.yyyy, hh:mm:ss");
+    private static final DateFormat dt = new SimpleDateFormat("dd.MM.yyyy, hh:mm:ss", Locale.getDefault());
 
     public DatabaseHandler(Context context) {
         super(context, DATABASE_NAME, null, DATABASE_VERSION);
@@ -167,12 +168,9 @@ public class DatabaseHandler extends SQLiteOpenHelper {
      */
     public int getNoteCount() {
         SQLiteDatabase db = getReadableDatabase();
-        Cursor cursor = db.rawQuery("SELECT * FROM " + TABLE_NOTES, null);
-        int result = cursor.getCount();
-
-        cursor.close();
+        int numberOfNotes = (int) DatabaseUtils.queryNumEntries(db, TABLE_NOTES);
         db.close();
-        return result;
+        return numberOfNotes;
     }
 
     /**
@@ -200,7 +198,7 @@ public class DatabaseHandler extends SQLiteOpenHelper {
      * Method used to get all notes in Database
      * @return ArrayList of Notes, containing all notes in Database
      */
-    public List<Note> getAllNotesAsArrayList() {
+    public ArrayList<Note> getAllNotesAsArrayList() {
         ArrayList<Note> notes = new ArrayList<>();
 
         SQLiteDatabase db = getWritableDatabase();

--- a/app/src/main/java/com/example/tomek/notepad/DatabaseHandler.java
+++ b/app/src/main/java/com/example/tomek/notepad/DatabaseHandler.java
@@ -110,17 +110,17 @@ public class DatabaseHandler extends SQLiteOpenHelper {
             cursor.moveToFirst();
         }
 
-        String spannableAsHtml = cursor.getString(1);
+        String spannableAsHtml = cursor.getString(cursor.getColumnIndex(KEY_SPANNABLE_NOTE));
         // :)))))
         Spannable spannable = (Spannable) Html.fromHtml(Html.toHtml(Html.fromHtml(spannableAsHtml)));
 
-        Bitmap image = BitmapConverter.getImage(cursor.getBlob(2));
+        Bitmap image = BitmapConverter.getImage(cursor.getBlob(cursor.getColumnIndex(KEY_IMAGE)));
 
         //Default val
         Date date;
 
         try {
-            date = dt.parse(cursor.getString(3));
+            date = dt.parse(cursor.getString(cursor.getColumnIndex(KEY_DATE_UPDATED)));
         } catch (Exception e) {
             date = new Date();
             e.printStackTrace();
@@ -128,7 +128,7 @@ public class DatabaseHandler extends SQLiteOpenHelper {
 
         String title;
         try {
-            title = cursor.getString(4); //TODO: replace integers with column keys
+            title = cursor.getString(cursor.getColumnIndex(KEY_NOTE_TITLE));
         }catch (Exception e){
             title = "";
             e.printStackTrace();
@@ -201,14 +201,14 @@ public class DatabaseHandler extends SQLiteOpenHelper {
 
         if (cursor.moveToFirst()) {
             do {
-                int id = Integer.parseInt(cursor.getString(0));
-                Spannable spannable = (Spannable) Html.fromHtml(cursor.getString(1));
-                Bitmap image = BitmapConverter.getImage(cursor.getBlob(2));
+                int id = Integer.parseInt(cursor.getString(cursor.getColumnIndex(KEY_ID)));
+                Spannable spannable = (Spannable) Html.fromHtml(cursor.getString(cursor.getColumnIndex(KEY_SPANNABLE_NOTE)));
+                Bitmap image = BitmapConverter.getImage(cursor.getBlob(cursor.getColumnIndex(KEY_IMAGE)));
                 //Default val
                 Date date;
 
                 try {
-                    date = dt.parse(cursor.getString(3));
+                    date = dt.parse(cursor.getString(cursor.getColumnIndex(KEY_DATE_UPDATED)));
                 } catch (Exception e) {
                     date = new Date();
                     e.printStackTrace();
@@ -216,7 +216,7 @@ public class DatabaseHandler extends SQLiteOpenHelper {
 
                 String title;
                 try {
-                    title = cursor.getString(4);
+                    title = cursor.getString(cursor.getColumnIndex(KEY_NOTE_TITLE));
                 } catch (Exception e) {
                     title = "";
                     e.printStackTrace();
@@ -243,14 +243,14 @@ public class DatabaseHandler extends SQLiteOpenHelper {
 
         if (cursor.moveToFirst()) {
             do {
-                int id = Integer.parseInt(cursor.getString(0));
-                Spannable spannable = (Spannable) Html.fromHtml(cursor.getString(1));
-                Bitmap image = BitmapConverter.getImage(cursor.getBlob(2));
+                int id = Integer.parseInt(cursor.getString(cursor.getColumnIndex(KEY_ID)));
+                Spannable spannable = (Spannable) Html.fromHtml(cursor.getString(cursor.getColumnIndex(KEY_SPANNABLE_NOTE)));
+                Bitmap image = BitmapConverter.getImage(cursor.getBlob(cursor.getColumnIndex(KEY_IMAGE)));
                 //Default val
                 Date date;
 
                 try {
-                    date = dt.parse(cursor.getString(3));
+                    date = dt.parse(cursor.getString(cursor.getColumnIndex(KEY_DATE_UPDATED)));
                 } catch (Exception e) {
                     date = new Date();
                     e.printStackTrace();
@@ -258,7 +258,7 @@ public class DatabaseHandler extends SQLiteOpenHelper {
 
                 String title;
                 try {
-                    title = cursor.getString(4);
+                    title = cursor.getString(cursor.getColumnIndex(KEY_NOTE_TITLE));
                 } catch (Exception e) {
                     title = "";
                     e.printStackTrace();

--- a/app/src/main/java/com/example/tomek/notepad/DatabaseHandler.java
+++ b/app/src/main/java/com/example/tomek/notepad/DatabaseHandler.java
@@ -117,7 +117,7 @@ public class DatabaseHandler extends SQLiteOpenHelper {
         Bitmap image = BitmapConverter.getImage(cursor.getBlob(2));
 
         //Default val
-        Date date = new Date();
+        Date date;
 
         try {
             date = dt.parse(cursor.getString(3));
@@ -126,10 +126,11 @@ public class DatabaseHandler extends SQLiteOpenHelper {
             e.printStackTrace();
         }
 
-        String title = "";
+        String title;
         try {
             title = cursor.getString(4); //TODO: replace integers with column keys
         }catch (Exception e){
+            title = "";
             e.printStackTrace();
         }
 
@@ -204,7 +205,7 @@ public class DatabaseHandler extends SQLiteOpenHelper {
                 Spannable spannable = (Spannable) Html.fromHtml(cursor.getString(1));
                 Bitmap image = BitmapConverter.getImage(cursor.getBlob(2));
                 //Default val
-                Date date = new Date();
+                Date date;
 
                 try {
                     date = dt.parse(cursor.getString(3));
@@ -213,11 +214,11 @@ public class DatabaseHandler extends SQLiteOpenHelper {
                     e.printStackTrace();
                 }
 
-                String title = "";
+                String title;
                 try {
                     title = cursor.getString(4);
                 } catch (Exception e) {
-                    date = new Date();
+                    title = "";
                     e.printStackTrace();
                 }
 
@@ -246,7 +247,7 @@ public class DatabaseHandler extends SQLiteOpenHelper {
                 Spannable spannable = (Spannable) Html.fromHtml(cursor.getString(1));
                 Bitmap image = BitmapConverter.getImage(cursor.getBlob(2));
                 //Default val
-                Date date = new Date();
+                Date date;
 
                 try {
                     date = dt.parse(cursor.getString(3));
@@ -255,11 +256,11 @@ public class DatabaseHandler extends SQLiteOpenHelper {
                     e.printStackTrace();
                 }
 
-                String title = "";
+                String title;
                 try {
                     title = cursor.getString(4);
                 } catch (Exception e) {
-                    date = new Date();
+                    title = "";
                     e.printStackTrace();
                 }
 

--- a/app/src/main/java/com/example/tomek/notepad/MainActivity.java
+++ b/app/src/main/java/com/example/tomek/notepad/MainActivity.java
@@ -40,8 +40,8 @@ public class MainActivity extends AppCompatActivity {
     private Note selectedNote;
 
     // Variables used to handle note list
-    public static NoteAdapter noteAdapter; // TODO is static ok?
-    public static ListView listView;
+    public NoteAdapter noteAdapter;
+    public ListView listView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -55,7 +55,7 @@ public class MainActivity extends AppCompatActivity {
 
         // Add items to ListView
         listView = (ListView) findViewById(R.id.listView);
-        populateListView((ArrayList<Note>) dbHandler.getAllNotesAsArrayList());
+        populateListView(dbHandler.getAllNotesAsArrayList());
 
         // Assign listView to context menu
         registerForContextMenu(listView);
@@ -205,7 +205,7 @@ public class MainActivity extends AppCompatActivity {
     /**
      * Method used to enter note edition mode
      *
-     * @param noteId
+     * @param noteId ID number of the Note entry in the SQLite database
      */
     private void editNote(int noteId) {
         hideSoftKeyboard();
@@ -234,10 +234,20 @@ public class MainActivity extends AppCompatActivity {
      *
      * @param note Array of Notes containing all Notes in Database
      */
-    private void populateListView(ArrayList<Note> note) {
+    void populateListView(ArrayList<Note> note) {
         noteAdapter = new NoteAdapter(this,
                 R.layout.listview_item_row, note);
         listView.setAdapter(noteAdapter);
+    }
+
+    public void setListViewData(ArrayList<Note> allNotes, Note newNote) {
+        if (noteAdapter != null) {
+            if (newNote != null){
+                noteAdapter.add(newNote);
+            }
+            noteAdapter.setData(allNotes);
+            noteAdapter.notifyDataSetChanged();
+        }
     }
 
     @Override
@@ -249,7 +259,7 @@ public class MainActivity extends AppCompatActivity {
             ListView listViewLocal = (ListView) v;
             AdapterView.AdapterContextMenuInfo acmi = (AdapterView.AdapterContextMenuInfo) menuInfo;
             selectedNote = (Note) listViewLocal.getItemAtPosition(acmi.position);
-            menu.setHeaderTitle(String.format(v.getContext().getString(R.string.choose_activity, selectedNote.getId())));
+            menu.setHeaderTitle(String.format(v.getContext().getString(R.string.choose_activity), selectedNote.getId()));
             MenuInflater inflater = getMenuInflater();
             inflater.inflate(R.menu.context_menu_note_select, menu);
         }
@@ -269,4 +279,5 @@ public class MainActivity extends AppCompatActivity {
         }
         return super.onContextItemSelected(item);
     }
+
 }

--- a/app/src/main/java/com/example/tomek/notepad/Note.java
+++ b/app/src/main/java/com/example/tomek/notepad/Note.java
@@ -18,6 +18,9 @@ public class Note {
     // Spannable used to format text
     private final Spannable mSpannable;
 
+    //
+    private final String mTitle;
+
     // Raw text used to make titles
     private final String rawText;
 
@@ -34,8 +37,9 @@ public class Note {
 
 
 
-    public Note(int id, Spannable spannable, Bitmap image, Date dateUpdated) {
+    public Note(int id, String title, Spannable spannable, Bitmap image, Date dateUpdated) {
         mId = id;
+        mTitle = title;
         mSpannable = spannable;
         mImage = image;
         rawText = mSpannable.toString();
@@ -44,6 +48,10 @@ public class Note {
 
     public int getId() {
         return mId;
+    }
+
+    public String getTitle(){
+        return mTitle;
     }
 
     public Spannable getSpannable() {

--- a/app/src/main/java/com/example/tomek/notepad/Note.java
+++ b/app/src/main/java/com/example/tomek/notepad/Note.java
@@ -6,6 +6,7 @@ import android.text.Spannable;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
 /**
  * Class that represents single Note
@@ -31,7 +32,7 @@ public class Note {
     private Date dateUpdated = new Date();
 
     //Formatter
-    private static final DateFormat dt = new SimpleDateFormat("dd.MM.yyyy, hh:mm:ss");
+    private static final DateFormat dt = new SimpleDateFormat("dd.MM.yyyy, hh:mm:ss", Locale.getDefault());
 
 
 

--- a/app/src/main/java/com/example/tomek/notepad/NoteActivity.java
+++ b/app/src/main/java/com/example/tomek/notepad/NoteActivity.java
@@ -4,6 +4,7 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.database.sqlite.SQLiteException;
 import android.graphics.Color;
 import android.graphics.Point;
 import android.graphics.Typeface;
@@ -402,12 +403,16 @@ public class NoteActivity extends AppCompatActivity {
      */
     private void loadNote(int noteID) {
 
-        Note n = dbHandler.getNote(noteID);
-        //todo fix
-        editText.setText(n.getSpannable());
-        editText.setSelection(editText.getText().toString().length());
-        noteTitle.setText(n.getTitle());
-        drawingView.setBitmap(n.getImage());
+        try {
+            Note n = dbHandler.getNote(noteID);
+            //todo fix
+            editText.setText(n.getSpannable());
+            editText.setSelection(editText.getText().toString().length());
+            noteTitle.setText(n.getTitle());
+            drawingView.setBitmap(n.getImage());
+        }catch (SQLiteException e){
+            e.printStackTrace();
+        }
     }
 
     /**

--- a/app/src/main/java/com/example/tomek/notepad/NoteActivity.java
+++ b/app/src/main/java/com/example/tomek/notepad/NoteActivity.java
@@ -399,7 +399,7 @@ public class NoteActivity extends AppCompatActivity {
     /**
      * Method used to add note text to EditText
      *
-     * @param noteID
+     * @param noteID ID number of the Note entry in the SQLite database
      */
     private void loadNote(int noteID) {
 

--- a/app/src/main/java/com/example/tomek/notepad/NoteActivity.java
+++ b/app/src/main/java/com/example/tomek/notepad/NoteActivity.java
@@ -87,6 +87,9 @@ public class NoteActivity extends AppCompatActivity {
     // (is -1 when it's new note)
     private int noteID;
 
+    // Title of note
+    private EditText noteTitle;
+
     // EditText panel
     private EditText editText;
 
@@ -104,6 +107,7 @@ public class NoteActivity extends AppCompatActivity {
         setContentView(R.layout.activity_note);
 
         // Set Views fields values
+        noteTitle = (EditText) findViewById(R.id.activity_note_title);
         editText = (EditText) findViewById(R.id.editText);
         mSliderLayout = (LinearLayout) findViewById(R.id.formatTextSlider);
         mDrawLayout = (LinearLayout) findViewById(R.id.drawPanelSlider);
@@ -315,7 +319,7 @@ public class NoteActivity extends AppCompatActivity {
      * @param editText EditText to apply changes to
      */
     private static void disableSoftInputFromAppearing(EditText editText) {
-        if (Build.VERSION.SDK_INT >= 11) {
+        if (Build.VERSION.SDK_INT >= 11) { //TODO: remove
             editText.setRawInputType(InputType.TYPE_CLASS_TEXT);
             editText.setTextIsSelectable(true);
         } else {
@@ -398,10 +402,12 @@ public class NoteActivity extends AppCompatActivity {
      */
     private void loadNote(int noteID) {
 
+        Note n = dbHandler.getNote(noteID);
         //todo fix
-        editText.setText(dbHandler.getNote(noteID).getSpannable());
+        editText.setText(n.getSpannable());
         editText.setSelection(editText.getText().toString().length());
-        drawingView.setBitmap(dbHandler.getNote(noteID).getImage());
+        noteTitle.setText(n.getTitle());
+        drawingView.setBitmap(n.getImage());
     }
 
     /**
@@ -411,12 +417,13 @@ public class NoteActivity extends AppCompatActivity {
     public void saveOrUpdateNote(@Nullable MenuItem menu) {
 
         spannable = editText.getText();
+        String title = noteTitle.getText().toString();
 
         if (noteID == -1) {
-            Note note = new Note(dbHandler.getNoteCount(), spannable, drawingView.getCanvasBitmap(), new Date());
+            Note note = new Note(dbHandler.getNoteCount(), title, spannable, drawingView.getCanvasBitmap(), new Date());
             new SaveOrUpdateNoteTask(this, dbHandler, false).execute(note);
         } else {
-            Note note = new Note(noteID, spannable, drawingView.getCanvasBitmap(), new Date());
+            Note note = new Note(noteID, title, spannable, drawingView.getCanvasBitmap(), new Date());
             new SaveOrUpdateNoteTask(this, dbHandler, true).execute(note);
         }
 

--- a/app/src/main/java/com/example/tomek/notepad/NoteAdapter.java
+++ b/app/src/main/java/com/example/tomek/notepad/NoteAdapter.java
@@ -2,13 +2,13 @@ package com.example.tomek.notepad;
 
 import android.app.Activity;
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.TextView;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class NoteAdapter extends ArrayAdapter<Note> {
@@ -25,7 +25,8 @@ public class NoteAdapter extends ArrayAdapter<Note> {
     }
 
     @Override
-    public View getView(int position, View convertView, ViewGroup parent) {
+    @NonNull
+    public View getView(int position, View convertView, @NonNull ViewGroup parent) {
         View row = convertView;
         NoteHolder holder;
 
@@ -68,14 +69,14 @@ public class NoteAdapter extends ArrayAdapter<Note> {
     }
 
     public void setData(List<Note> data) {
-        this.data = (ArrayList<Note>) data;
+        this.data = data;
     }
 
     public List<Note> getData() {
         return data;
     }
 
-    static class NoteHolder
+    private static class NoteHolder
     {
         private TextView noteTitle;
         private TextView noteContent;

--- a/app/src/main/java/com/example/tomek/notepad/NoteAdapter.java
+++ b/app/src/main/java/com/example/tomek/notepad/NoteAdapter.java
@@ -48,7 +48,10 @@ public class NoteAdapter extends ArrayAdapter<Note> {
         }
 
         Note note = data.get(position);
-        holder.noteTitle.setText(String.format(context.getString(R.string.note_number), note.getId()));
+        String noteTitle = note.getTitle();
+        if (noteTitle == null || noteTitle.length() == 0)
+            noteTitle = String.format(context.getString(R.string.note_number), note.getId());
+        holder.noteTitle.setText(noteTitle);
 
         String title = note.getRawText();
         if (title.length() != 0) {

--- a/app/src/main/java/com/example/tomek/notepad/SaveOrUpdateNoteTask.java
+++ b/app/src/main/java/com/example/tomek/notepad/SaveOrUpdateNoteTask.java
@@ -1,16 +1,19 @@
 package com.example.tomek.notepad;
 
 import android.app.Activity;
+import android.app.Application;
 import android.os.AsyncTask;
+import android.os.Bundle;
 import android.widget.Toast;
 
 import java.util.ArrayList;
 
-public class SaveOrUpdateNoteTask extends AsyncTask<Note, Void, Void> {
+public class SaveOrUpdateNoteTask extends AsyncTask<Note, Void, Void> implements Application.ActivityLifecycleCallbacks {
 
     private final Activity mCallingActivity;
     private final DatabaseHandler mDbHandler;
     private final boolean mIsUpdating;
+    private Activity currentActivity = null;
 
 
     /**
@@ -23,6 +26,7 @@ public class SaveOrUpdateNoteTask extends AsyncTask<Note, Void, Void> {
         mCallingActivity = callingActivity;
         mDbHandler = databaseHandler;
         mIsUpdating = isUpdating;
+        callingActivity.getApplication().registerActivityLifecycleCallbacks(this);
     }
 
     @Override
@@ -44,15 +48,47 @@ public class SaveOrUpdateNoteTask extends AsyncTask<Note, Void, Void> {
     @Override
     protected void onPostExecute(Void result) {
 
-        ArrayList<Note> allNotes = (ArrayList<Note>) mDbHandler.getAllNotesAsArrayList();
-
         if (mIsUpdating) {
             Toast.makeText(mCallingActivity, mCallingActivity.getString(R.string.toast_note_updated), Toast.LENGTH_SHORT).show();
         } else {
             Toast.makeText(mCallingActivity, mCallingActivity.getString(R.string.toast_note_created), Toast.LENGTH_SHORT).show();
-            MainActivity.noteAdapter.add(allNotes.get(mDbHandler.getNoteCount() - 1));
         }
-        MainActivity.noteAdapter.setData(allNotes);
-        MainActivity.noteAdapter.notifyDataSetChanged();
+
+        updateNoteListView();
+
     }
+
+    private void updateNoteListView(){
+        if (currentActivity != null && currentActivity instanceof MainActivity){
+            ArrayList<Note> allNotes = mDbHandler.getAllNotesAsArrayList();
+            Note newNote = null;
+            if (!mIsUpdating){
+                newNote = allNotes.get(mDbHandler.getNoteCount() - 1);
+            }
+            ((MainActivity) currentActivity).setListViewData(allNotes, newNote);
+        }
+    }
+
+    @Override
+    public void onActivityCreated(Activity activity, Bundle savedInstanceState) {}
+
+    @Override
+    public void onActivityStarted(Activity activity) {}
+
+    @Override
+    public void onActivityResumed(Activity activity) {
+        currentActivity = activity;
+    }
+
+    @Override
+    public void onActivityPaused(Activity activity) {}
+
+    @Override
+    public void onActivityStopped(Activity activity) {}
+
+    @Override
+    public void onActivitySaveInstanceState(Activity activity, Bundle outState) {}
+
+    @Override
+    public void onActivityDestroyed(Activity activity) {}
 }

--- a/app/src/main/res/layout/activity_note.xml
+++ b/app/src/main/res/layout/activity_note.xml
@@ -22,6 +22,16 @@
         android:orientation="vertical">
 
         <EditText
+            android:id="@+id/activity_note_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="10dp"
+            android:layout_marginRight="10dp"
+            android:layout_marginTop="5dp"
+            android:maxLength="100"
+            android:hint="Enter title (optional)"/>
+
+        <EditText
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -33,7 +33,7 @@
 	<string name="save_note_confirmation">変更を保存しますか?</string>
 
 	<!-- Used in NoteAdapter.java -->
-	<string name="note_number">メモ No: %s</string>
+	<string name="note_number">メモ No: %d</string>
 	<string name="note_has_no_text">Note has no text.</string> <!-- TODO: Japan translation of this one -->
 
 	<!-- Shared between MainActivity.java & NoteActivity.java -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -22,11 +22,11 @@
 	<string name="search_hint">メモを検索…</string>
 	<string name="confirmation">よろしいですか?</string>
 	<string name="close_app">アプリケーションを閉じる</string>
-	<string name="delete_note_number">メモ #%s を削除</string>
-	<string name="note_deleted">メモ #%s を削除しました</string>
+	<string name="delete_note_number">メモ #%d を削除</string>
+	<string name="note_deleted">メモ #%d を削除しました</string>
 	<string name="delete_notes_title">すべてのメモを削除</string>
 	<string name="delete_notes_success">すべてのメモを削除しました!</string>
-	<string name="choose_activity">メモ #%s の操作を選択してください</string>
+	<string name="choose_activity">メモ #%d の操作を選択してください</string>
 
 	<!-- Used in NoteActivity.java -->
 	<string name="save_note_title">メモを保存</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -33,7 +33,7 @@
 	<string name="save_note_confirmation">Czy chcesz zapisać zmiany?</string>
 
 	<!-- Used in NoteAdapter.java -->
-	<string name="note_number">Notatka nr. %s</string>
+	<string name="note_number">Notatka nr. %d</string>
 	<string name="note_has_no_text">Pusta notatka.</string>
 
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -22,11 +22,11 @@
 	<string name="search_hint">Szukaj notatek…</string>
 	<string name="confirmation">Jesteś pewien?</string>
 	<string name="close_app">Zamknij aplikację</string>
-	<string name="delete_note_number">Usuń notatkę #%s</string>
-	<string name="note_deleted">Notatka #%s została usunięta</string>
+	<string name="delete_note_number">Usuń notatkę #%d</string>
+	<string name="note_deleted">Notatka #%d została usunięta</string>
 	<string name="delete_notes_title">Usuń wszystkie notatki</string>
 	<string name="delete_notes_success">Wszystkie notatki zostały usunięte!</string>
-	<string name="choose_activity">Wybierz akcję dla notatki #%s</string>
+	<string name="choose_activity">Wybierz akcję dla notatki #%d</string>
 
 	<!-- Used in NoteActivity.java -->
 	<string name="save_note_title">Zapisz notatkę</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,11 +22,11 @@
 	<string name="search_hint">Search notes…</string>
 	<string name="confirmation">Are you sure?</string>
 	<string name="close_app">Close Application</string>
-	<string name="delete_note_number">Delete note #%s</string>
-	<string name="note_deleted">Note #%s deleted</string>
+	<string name="delete_note_number">Delete note #%d</string>
+	<string name="note_deleted">Note #%d deleted</string>
 	<string name="delete_notes_title">Delete all notes</string>
 	<string name="delete_notes_success">All notes have been deleted!</string>
-	<string name="choose_activity">Choose action for note #%s</string>
+	<string name="choose_activity">Choose action for note #%d</string>
 
 	<!-- Used in NoteActivity.java -->
 	<string name="save_note_title">Save note</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,7 +33,7 @@
 	<string name="save_note_confirmation">Do you want to save changes?</string>
 
 	<!-- Used in NoteAdapter.java -->
-	<string name="note_number">Note No: %s</string>
+	<string name="note_number">Note No: %d</string>
 	<string name="note_has_no_text">Note has no text.</string>
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.1'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
Updated build tools and target SDK to allow for Android 7 support
Added a note title field (Issue #20 ), so users can optionally set their own title instead of "Note No: %d"
Replaced the static GUI elements in MainActivity with a callback, so it still functions the same, but gets rid of the implications of a static context
Various minor fixes and updates

There's a new string which should be translated. The string is the hint for the title field of a note.

Also, I'm not certain of your intent with forcing portrait. I've replaced it with "locked" (see latest commit).
